### PR TITLE
Updated: location of steps for making labels stale

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -1,7 +1,7 @@
 name: Labeled Events
 on:
   pull_request_target:
-    types: [labeled, opened, synchronize, reopened]
+    types: [labeled]
 env:
   INTERNAL_REPO: NCR-Corporation/gsre-internal
   TESTS_PASSED: tests-passed
@@ -12,6 +12,7 @@ env:
   UPLOAD_LABEL: upload2testpypi
   TESTPYPI_UPLOADED: testpypi-uploaded
   TESTPYPI_UPLOAD_FAILED: testpypi-upload-failed
+  TESTPYPI_STALE: testpypi-stale
   NON_RELEASE_LABEL: non-release
 jobs:
   verify:
@@ -106,17 +107,10 @@ jobs:
           echo "Success"
       - name: Upload Failed
         if: github.event.label.name == 'env.TESTPYPI_UPLOAD_FAILED' || contains(github.event.pull_request.labels.*.name, env.TESTPYPI_UPLOAD_FAILED)
-        run: |
-          echo "Failure"
-          exit 1
-      - name: Stale testpypi
-        if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, env.TESTPYPI_UPLOADED)
-        run: |
-          echo "testpypi upload made stale by new commit"
-          gh pr edit ${{github.event.number}} --remove-label $TESTPYPI_UPLOADED -R ${{github.repository}}
-          exit 1
-        env:
-          GITHUB_TOKEN: ${{secrets.GA_PAT }}
+        run: echo "Failure" && exit 1
+      - name: Upload Stale
+        if: contains(github.event.pull_request.labels.*.name, env.TESTPYPI_STALE)
+        run: echo "Testpypi upload is stale" && exit 1
       - name: Non release
         if: contains(github.event.pull_request.labels.*.name, needs.verify.outputs.non_release_label)
         run: |

--- a/.github/workflows/pr_events.yml
+++ b/.github/workflows/pr_events.yml
@@ -13,6 +13,9 @@ env:
   VERSION_LABEL: updated-version
   INTERNAL_REPO: NCR-Corporation/gsre-internal
   NON_RELEASE_LABEL: non-release
+  TESTPYPI_UPLOADED: testpypi-uploaded
+  TESTPYPI_STALE: testpypi-stale
+  TESTS_PASSED: tests-passed
 jobs:
   # wf level env vars are not accessible to job level if conditions but outputs of jobs in needs are
   env-vars:
@@ -21,6 +24,18 @@ jobs:
       non_release_label: ${{env.NON_RELEASE_LABEL}}  
     steps:
       - run: echo "${{toJSON(github)}}"
+      - name: Stale testpypi
+        if: github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, env.TESTPYPI_UPLOADED)
+        run: |
+          echo "testpypi upload made stale by new commit"
+          gh pr edit ${{github.event.number}} --add-label $TESTPYPI_STALE --remove-label $TESTPYPI_UPLOADED -R ${{github.repository}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GA_PAT }}
+      - name: Stale Tests
+        if: contains(github.event.pull_request.labels.*.name, env.TESTS_PASSED)
+        run: |
+          echo "tests passed made stale by new commit"
+          gh pr edit ${{github.event.number}} --remove-label $TESTS_PASSED -R ${{github.repository}}
   trigger_sonar:
     needs: [env-vars]
     name: Run Sonar and Coverity Scans


### PR DESCRIPTION
# Checklist

- [ ] verision number is updated or the package is new
- [ ] project contains a valid license, specifically Apache v2.0.
- [ ] project passes all sonar and coverity checks
- [ ] project uploaded to the testpypi server using upload2testpypi label to trigger an upload
- [ ] approval from code owners

Once all 5 of these tasks have been completed, the pr is ready to be merged and pushed to the pypi server.

:memo: __NOTE if this PR contains changes that do not require a package update such as a modification to documentation or workflow files then label the PR 'non-release' to skip all these checks and avoid uploading a new change to the package server__
