### PR TITLE
Fixed: missing repo info in gh pr calls

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -70,14 +70,14 @@ jobs:
       - name: Merge pr
         id: fork
         run: | 
-          gh pr merge ${{github.event.number}} --merge
-          echo "::set-output name=assignee::$(gh pr view ${{github.event.number}} --json assignees --jq '.assignees[0].login')"
-          echo "::set-output name=title::$(gh pr view ${{github.event.number}} --json "title" --jq '.title')"
+          gh pr merge ${{github.event.number}} --merge -R ${{github.repository}}
+          echo "::set-output name=assignee::$(gh pr view ${{github.event.number}} -R ${{github.repository}} --json assignees --jq '.assignees[0].login')"
+          echo "::set-output name=title::$(gh pr view ${{github.event.number}} -R ${{github.repository}} --json "title" --jq '.title')"
       - name: Open new pr
         id: new-pr
-        run: echo "::set-output name=link::$(gh pr create --base "${{github.event.pull_request.base.repo.default_branch}}" --head "${new_branch}" --title "${{steps.fork.outputs.title}}" --assignee "${{steps.fork.outputs.assignee}}")"
+        run: echo "::set-output name=link::$(gh pr create --base "${{github.event.pull_request.base.repo.default_branch}}" --head "${new_branch}" --title "${{steps.fork.outputs.title}}" --assignee "${{steps.fork.outputs.assignee}}" -R ${{github.repository}})"
       - name: Comment link to new pr on merged fork
-        run: gh pr comment ${{github.event.number}} --body "This PR has been approved and moved to a new pr ${{steps.new-pr.outputs.link}}"
+        run: gh pr comment ${{github.event.number}} --body "This PR has been approved and moved to a new pr ${{steps.new-pr.outputs.link}}" -R ${{github.repository}}
 
   sonar-cover:
     name: Sonar and Coverity Scans


### PR DESCRIPTION
# Checklist

- [ ] version number is updated or the package is new
- [ ] project contains a valid license, specifically Apache v2.0.
- [ ] project passes all sonar and coverity checks
- [ ] project uploaded to the testpypi server using upload2testpypi label to trigger an upload
- [ ] approval from code owners

Once all 5 of these criteria/tasks have been completed, the pr is ready to be merged and pushed to the pypi server.

:memo: __NOTE if this PR contains changes that do not require a package update such as a modification to documentation or workflow files then label the PR 'non-release' to skip all these checks and avoid uploading a new change to the package server__
