### PR TITLE
Fixed: pr create

### DIFF
--- a/.github/workflows/labels.yml
+++ b/.github/workflows/labels.yml
@@ -75,7 +75,9 @@ jobs:
           echo "::set-output name=title::$(gh pr view ${{github.event.number}} -R ${{github.repository}} --json "title" --jq '.title')"
       - name: Open new pr
         id: new-pr
-        run: echo "::set-output name=link::$(gh pr create --base "${{github.event.pull_request.base.repo.default_branch}}" --head "${new_branch}" --title "${{steps.fork.outputs.title}}" --assignee "${{steps.fork.outputs.assignee}}" -R ${{github.repository}})"
+        run: |
+          echo "The new branch name is ${new_branch}"
+          echo "::set-output name=link::$(gh pr create --base "${{github.event.pull_request.base.repo.default_branch}}" --body "" --head "${new_branch}" --title "${{steps.fork.outputs.title}}" --assignee "${{steps.fork.outputs.assignee}}" -R ${{github.repository}})"
       - name: Comment link to new pr on merged fork
         run: gh pr comment ${{github.event.number}} --body "This PR has been approved and moved to a new pr ${{steps.new-pr.outputs.link}}" -R ${{github.repository}}
 


### PR DESCRIPTION
# Checklist

- [ ] version number is updated or the package is new
- [ ] project contains a valid license, specifically Apache v2.0.
- [ ] project passes all sonar and coverity checks
- [ ] project uploaded to the testpypi server using upload2testpypi label to trigger an upload
- [ ] approval from code owners

Once all 5 of these criteria/tasks have been completed, the pr is ready to be merged and pushed to the pypi server.

:memo: __NOTE if this PR contains changes that do not require a package update such as a modification to documentation or workflow files then label the PR 'non-release' to skip all these checks and avoid uploading a new change to the package server__
